### PR TITLE
/api/v1/instanceにmax_toot_charsを追加

### DIFF
--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -11,6 +11,7 @@ export const boostModal = getMeta('boost_modal');
 export const deleteModal = getMeta('delete_modal');
 export const me = getMeta('me');
 export const searchEnabled = getMeta('search_enabled');
+export const maxChars = getMeta('max_toot_chars') || 1024;
 export const invitesEnabled = getMeta('invites_enabled');
 export const version = getMeta('version');
 

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -2,9 +2,14 @@
 
 class InitialStateSerializer < ActiveModel::Serializer
   attributes :meta, :compose, :accounts,
-             :media_attachments, :settings
+             :media_attachments, :settings,
+             :max_toot_chars
 
   has_one :push_subscription, serializer: REST::WebPushSubscriptionSerializer
+
+  def max_toot_chars
+    StatusLengthValidator::MAX_CHARS
+  end
 
   def meta
     store = {

--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -4,7 +4,7 @@ class REST::InstanceSerializer < ActiveModel::Serializer
   include RoutingHelper
 
   attributes :uri, :title, :description, :email,
-             :version, :urls, :stats, :thumbnail,
+             :version, :urls, :stats, :thumbnail, :max_toot_chars,
              :languages
 
   has_one :contact_account, serializer: REST::AccountSerializer
@@ -33,6 +33,10 @@ class REST::InstanceSerializer < ActiveModel::Serializer
 
   def thumbnail
     instance_presenter.thumbnail ? full_asset_url(instance_presenter.thumbnail.file.url) : full_pack_url('preview.jpg')
+  end
+
+  def max_toot_chars
+    StatusLengthValidator::MAX_CHARS
   end
 
   def stats


### PR DESCRIPTION
タイトル通り

今回はちゃんとローカル環境でテスト済みです
**https://localhost/api/v1/instance**
`{"uri":"localhost","title":"Mastodon","description":"","email":"","version":"2.5.0","urls":{"streaming_api":"wss://localhost"},"stats":{"user_count":2,"status_count":19,"domain_count":1},"thumbnail":"https://localhost/packs/preview-9a17d32fc48369e8ccd910a75260e67d.jpg","max_toot_chars":1024,"languages":["en"],"contact_account":null}`